### PR TITLE
[acme] remove rollout deploy option

### DIFF
--- a/charts/acme/Chart.yaml
+++ b/charts/acme/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.2.0
-appVersion: 1.2.0
+version: 1.3.0
+appVersion: 1.3.0
 name: acme
 description: SSL certificate automatic issue and renewal using acme.sh script. https://github.com/acmesh-official/acme.sh

--- a/charts/acme/files/acme.sh
+++ b/charts/acme/files/acme.sh
@@ -16,8 +16,6 @@ _notify_hook=""
 _force_option=""
 _secret=()
 _secret_namespace="default"
-_rollout_deployment=""
-_rollout_deployment_namespace="default"
 
 _acme_install() {
   curl https://get.acme.sh | sh -s email="$_email"
@@ -48,10 +46,6 @@ _acme_issue() {
     _renew_hook="$_renew_hook --secret $_secret --secret-namespace $_secret_namespace"
   fi
 
-  if [ ! -z "$_rollout_deployment" ]; then
-    _renew_hook="$_renew_hook --rollout-deployment $_rollout_deployment --rollout-deployment-namespace $_rollout_deployment_namespace"
-  fi
-
   acme.sh --issue \
     --keylength ec-256 \
     --dns dns_$_dns \
@@ -66,9 +60,7 @@ _acme_issue() {
     $_debug_option \
     -d "${_domains[0]}" \
     --secret "$_secret" \
-    --secret-namespace "$_secret_namespace" \
-    --rollout-deployment "$_rollout_deployment" \
-    --rollout-deployment-namespace "$_rollout_deployment_namespace"
+    --secret-namespace "$_secret_namespace"
 }
 
 _acme_install_cert() {
@@ -99,10 +91,6 @@ _acme_install_cert() {
       -o yaml \
       2>/dev/null | \
     kubectl apply -f -
-  fi
-
-  if [ ! -z "$_rollout_deployment" ]; then
-    kubectl rollout restart deployment/$_rollout_deployment -n $_rollout_deployment_namespace
   fi
 }
 
@@ -152,16 +140,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     --secret-namespace)
       _secret_namespace="$2"
-      shift # past argument
-      shift # past value
-      ;;
-    --rollout-deployment)
-      _rollout_deployment="$2"
-      shift # past argument
-      shift # past value
-      ;;
-    --rollout-deployment-namespace)
-      _rollout_deployment_namespace="$2"
       shift # past argument
       shift # past value
       ;;

--- a/charts/acme/values.yaml
+++ b/charts/acme/values.yaml
@@ -9,7 +9,6 @@ acme:
   domains: []
   notifyHook: ""
   sslCertSecretName: ssl-cert
-  rolloutDeploymentName: ""
 
 podLabels: {}
 


### PR DESCRIPTION
This option is no longer needed. I plan to switch to using traefik TLSStore which will automatically refresh certificates