### PR TITLE
add docker registry helm chart

### DIFF
--- a/charts/docker-registry/.helmignore
+++ b/charts/docker-registry/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/docker-registry/Chart.yaml
+++ b/charts/docker-registry/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+appVersion: 2.7.1
+description: A Helm chart for Docker Registry
+home: https://hub.docker.com/_/registry/
+icon: https://hub.docker.com/public/images/logos/mini-logo.svg
+maintainers:
+- email: jpds@protonmail.com
+  name: jpds
+- email: pete.brown@powerhrg.com
+  name: rendhalver
+name: docker-registry
+sources:
+- https://github.com/docker/distribution-library-image
+version: 1.0.0

--- a/charts/docker-registry/OWNERS
+++ b/charts/docker-registry/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- jpds
+- rendhalver
+reviewers:
+- jpds
+- rendhalver

--- a/charts/docker-registry/README.md
+++ b/charts/docker-registry/README.md
@@ -1,0 +1,84 @@
+# Docker Registry Helm Chart
+
+This directory contains a Kubernetes chart to deploy a private Docker Registry.
+
+## Prerequisites Details
+
+* PV support on underlying infrastructure (if persistence is required)
+
+## Chart Details
+
+This chart will do the following:
+
+* Implement a Docker registry deployment
+
+## Installing the Chart
+
+To install the chart, use the following:
+
+```console
+$ helm install stable/docker-registry
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the docker-registry chart and
+their default values.
+
+| Parameter                   | Description                                                                                | Default         |
+|:----------------------------|:-------------------------------------------------------------------------------------------|:----------------|
+| `image.pullPolicy`          | Container pull policy                                                                      | `IfNotPresent`  |
+| `image.repository`          | Container image to use                                                                     | `registry`      |
+| `image.tag`                 | Container image tag to deploy                                                              | `2.7.1`         |
+| `imagePullSecrets`          | Specify image pull secrets                                                                 | `nil` (does not add image pull secrets to deployed pods) |
+| `persistence.accessMode`    | Access mode to use for PVC                                                                 | `ReadWriteOnce` |
+| `persistence.enabled`       | Whether to use a PVC for the Docker storage                                                | `false`         |
+| `persistence.deleteEnabled` | Enable the deletion of image blobs and manifests by digest                                 | `nil`           |
+| `persistence.size`          | Amount of space to claim for PVC                                                           | `10Gi`          |
+| `persistence.storageClass`  | Storage Class to use for PVC                                                               | `-`             |
+| `persistence.existingClaim` | Name of an existing PVC to use for config                                                  | `nil`           |
+| `service.port`              | TCP port on which the service is exposed                                                   | `5000`          |
+| `service.type`              | service type                                                                               | `ClusterIP`     |
+| `service.clusterIP`         | if `service.type` is `ClusterIP` and this is non-empty, sets the cluster IP of the service | `nil`           |
+| `service.nodePort`          | if `service.type` is `NodePort` and this is non-empty, sets the node port of the service   | `nil`           |
+| `replicaCount`              | k8s replicas                                                                               | `1`             |
+| `updateStrategy`            | update strategy for deployment                                                             | `{}`            |
+| `podAnnotations`            | Annotations for pod                                                                        | `{}`            |
+| `podLabels`                 | Labels for pod                                                                             | `{}`            |
+| `podDisruptionBudget`       | Pod disruption budget                                                                      | `{}`            |
+| `resources.limits.cpu`      | Container requested CPU                                                                    | `nil`           |
+| `resources.limits.memory`   | Container requested memory                                                                 | `nil`           |
+| `priorityClassName      `   | priorityClassName                                                                          | `""`            |
+| `storage`                   | Storage system to use                                                                      | `filesystem`    |
+| `tlsSecretName`             | Name of secret for TLS certs                                                               | `nil`           |
+| `secrets.htpasswd`          | Htpasswd authentication                                                                    | `nil`           |
+| `secrets.s3.accessKey`      | Access Key for S3 configuration                                                            | `nil`           |
+| `secrets.s3.secretKey`      | Secret Key for S3 configuration                                                            | `nil`           |
+| `secrets.swift.username`    | Username for Swift configuration                                                           | `nil`           |
+| `secrets.swift.password`    | Password for Swift configuration                                                           | `nil`           |
+| `haSharedSecret`            | Shared secret for Registry                                                                 | `nil`           |
+| `configData`                | Configuration hash for docker                                                              | `nil`           |
+| `s3.region`                 | S3 region                                                                                  | `nil`           |
+| `s3.regionEndpoint`         | S3 region endpoint                                                                         | `nil`           |
+| `s3.bucket`                 | S3 bucket name                                                                             | `nil`           |
+| `s3.encrypt`                | Store images in encrypted format                                                           | `nil`           |
+| `s3.secure`                 | Use HTTPS                                                                                  | `nil`           |
+| `swift.authurl`             | Swift authurl                                                                              | `nil`           |
+| `swift.container`           | Swift container                                                                            | `nil`           |
+| `nodeSelector`              | node labels for pod assignment                                                             | `{}`            |
+| `affinity`                  | affinity settings                                                                          | `{}`            |
+| `tolerations`               | pod tolerations                                                                            | `[]`            |
+| `ingress.enabled`           | If true, Ingress will be created                                                           | `false`         |
+| `ingress.annotations`       | Ingress annotations                                                                        | `{}`            |
+| `ingress.labels`            | Ingress labels                                                                             | `{}`            |
+| `ingress.path`              | Ingress service path                                                                       | `/`             |
+| `ingress.hosts`             | Ingress hostnames                                                                          | `[]`            |
+| `ingress.tls`               | Ingress TLS configuration (YAML)                                                           | `[]`            |
+| `extraVolumeMounts`         | Additional volumeMounts to the registry container                                          | `[]`            |
+| `extraVolumes`              | Additional volumes to the pod                                                              | `[]`            |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to
+`helm install`.
+
+To generate htpasswd file, run this docker command:
+`docker run --entrypoint htpasswd registry:2 -Bbn user password > ./htpasswd`.

--- a/charts/docker-registry/templates/NOTES.txt
+++ b/charts/docker-registry/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "docker-registry.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "docker-registry.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "docker-registry.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "docker-registry.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 8080:5000
+{{- end }}

--- a/charts/docker-registry/templates/_helpers.tpl
+++ b/charts/docker-registry/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "docker-registry.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "docker-registry.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/docker-registry/templates/configmap.yaml
+++ b/charts/docker-registry/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "docker-registry.fullname" . }}-config
+  labels:
+    app: {{ template "docker-registry.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data:
+  config.yml: |-
+{{ toYaml .Values.configData | indent 4 }}

--- a/charts/docker-registry/templates/deployment.yaml
+++ b/charts/docker-registry/templates/deployment.yaml
@@ -1,0 +1,221 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "docker-registry.fullname" . }}
+  labels:
+    app: {{ template "docker-registry.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "docker-registry.name" . }}
+      release: {{ .Release.Name }}
+  replicas: {{ .Values.replicaCount }}
+{{- if .Values.updateStrategy }}
+  strategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
+{{- end }}
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        app: {{ template "docker-registry.name" . }}
+        release: {{ .Release.Name }}
+        {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- if $.Values.podAnnotations }}
+{{ toYaml $.Values.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+{{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+{{- end }}
+{{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+{{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+          - /bin/registry
+          - serve
+          - /etc/docker/registry/config.yml
+          ports:
+            - containerPort: 5000
+          livenessProbe:
+            httpGet:
+{{- if .Values.tlsSecretName }}
+              scheme: HTTPS
+{{- end }}
+              path: /
+              port: 5000
+          readinessProbe:
+            httpGet:
+{{- if .Values.tlsSecretName }}
+              scheme: HTTPS
+{{- end }}
+              path: /
+              port: 5000
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          env:
+{{- if .Values.secrets.htpasswd }}
+            - name: REGISTRY_AUTH
+              value: "htpasswd"
+            - name: REGISTRY_AUTH_HTPASSWD_REALM
+              value: "Registry Realm"
+            - name: REGISTRY_AUTH_HTPASSWD_PATH
+              value: "/auth/htpasswd"
+{{- end }}
+            - name: REGISTRY_HTTP_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "docker-registry.fullname" . }}-secret
+                  key: haSharedSecret
+{{- if .Values.tlsSecretName }}
+            - name: REGISTRY_HTTP_TLS_CERTIFICATE
+              value: /etc/ssl/docker/tls.crt
+            - name: REGISTRY_HTTP_TLS_KEY
+              value: /etc/ssl/docker/tls.key
+{{- end }}
+{{- if eq .Values.storage "filesystem" }}
+            - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
+              value: "/var/lib/registry"
+{{- else if eq .Values.storage "azure" }}
+            - name: REGISTRY_STORAGE_AZURE_ACCOUNTNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "docker-registry.fullname" . }}-secret
+                  key: azureAccountName
+            - name: REGISTRY_STORAGE_AZURE_ACCOUNTKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "docker-registry.fullname" . }}-secret
+                  key: azureAccountKey
+            - name: REGISTRY_STORAGE_AZURE_CONTAINER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "docker-registry.fullname" . }}-secret
+                  key: azureContainer
+{{- else if eq .Values.storage "s3" }}
+            {{- if and .Values.secrets.s3.secretKey .Values.secrets.s3.accessKey }}
+            - name: REGISTRY_STORAGE_S3_ACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "docker-registry.fullname" . }}-secret
+                  key: s3AccessKey
+            - name: REGISTRY_STORAGE_S3_SECRETKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "docker-registry.fullname" . }}-secret
+                  key: s3SecretKey
+            {{- end }}
+            - name: REGISTRY_STORAGE_S3_REGION
+              value: {{ required ".Values.s3.region is required" .Values.s3.region }}
+          {{- if .Values.s3.regionEndpoint }}
+            - name: REGISTRY_STORAGE_S3_REGIONENDPOINT
+              value: {{ .Values.s3.regionEndpoint }}
+          {{- end }}
+            - name: REGISTRY_STORAGE_S3_BUCKET
+              value: {{ required ".Values.s3.bucket is required" .Values.s3.bucket }}
+          {{- if .Values.s3.encrypt }}
+            - name: REGISTRY_STORAGE_S3_ENCRYPT
+              value: {{ .Values.s3.encrypt | quote }}
+          {{- end }}
+          {{- if .Values.s3.secure }}
+            - name: REGISTRY_STORAGE_S3_SECURE
+              value: {{ .Values.s3.secure | quote }}
+          {{- end }}
+{{- else if eq .Values.storage "swift" }}
+            - name: REGISTRY_STORAGE_SWIFT_AUTHURL
+              value: {{ required ".Values.swift.authurl is required" .Values.swift.authurl }}
+            - name: REGISTRY_STORAGE_SWIFT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "docker-registry.fullname" . }}-secret
+                  key: swiftUsername
+            - name: REGISTRY_STORAGE_SWIFT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "docker-registry.fullname" . }}-secret
+                  key: swiftPassword
+            - name: REGISTRY_STORAGE_SWIFT_CONTAINER
+              value: {{ required ".Values.swift.container is required" .Values.swift.container }}
+{{- end }}
+{{- if .Values.persistence.deleteEnabled }}
+            - name: REGISTRY_STORAGE_DELETE_ENABLED
+              value: "true"
+{{- end }}
+          volumeMounts:
+{{- if .Values.secrets.htpasswd }}
+            - name: auth
+              mountPath: /auth
+              readOnly: true
+{{- end }}
+{{- if eq .Values.storage "filesystem" }}
+            - name: data
+              mountPath: /var/lib/registry/
+{{- end }}
+            - name: "{{ template "docker-registry.fullname" . }}-config"
+              mountPath: "/etc/docker/registry"
+{{- if .Values.tlsSecretName }}
+            - mountPath: /etc/ssl/docker
+              name: tls-cert
+              readOnly: true
+{{- end }}
+{{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
+      volumes:
+{{- if .Values.secrets.htpasswd }}
+        - name: auth
+          secret:
+            secretName: {{ template "docker-registry.fullname" . }}-secret
+            items:
+            - key: htpasswd
+              path: htpasswd
+{{- end }}
+{{- if eq .Values.storage "filesystem" }}
+        - name: data
+      {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "docker-registry.fullname" . }}{{- end }}
+      {{- else }}
+          emptyDir: {}
+      {{- end -}}
+{{- end }}
+        - name: {{ template "docker-registry.fullname" . }}-config
+          configMap:
+            name: {{ template "docker-registry.fullname" . }}-config
+{{- if .Values.tlsSecretName }}
+        - name: tls-cert
+          secret:
+            secretName: {{ .Values.tlsSecretName }}
+{{- end }}
+{{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+{{- end }}

--- a/charts/docker-registry/templates/deployment.yaml
+++ b/charts/docker-registry/templates/deployment.yaml
@@ -110,7 +110,18 @@ spec:
                   name: {{ template "docker-registry.fullname" . }}-secret
                   key: azureContainer
 {{- else if eq .Values.storage "s3" }}
-            {{- if and .Values.secrets.s3.secretKey .Values.secrets.s3.accessKey }}
+            {{- if .Values.secrets.s3.existingSecret }}
+            - name: REGISTRY_STORAGE_S3_ACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.s3.existingSecret.name }}
+                  key: {{ .Values.secrets.s3.existingSecret.s3AccessKeySecretKey | default "s3AccessKey" }}
+            - name: REGISTRY_STORAGE_S3_SECRETKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.s3.existingSecret.name }}
+                  key: {{ .Values.secrets.s3.existingSecret.s3SecretKeySecretKey | default "s3SecretKey" }}
+            {{- else if and .Values.secrets.s3.secretKey .Values.secrets.s3.accessKey }}
             - name: REGISTRY_STORAGE_S3_ACCESSKEY
               valueFrom:
                 secretKeyRef:

--- a/charts/docker-registry/templates/ingress.yaml
+++ b/charts/docker-registry/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "docker-registry.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $path := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "docker-registry.fullname" . }}
+  labels:
+    app: {{ template "docker-registry.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.ingress.labels }}
+{{ toYaml .Values.ingress.labels | indent 4 }}
+{{- end }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: {{ $path }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/charts/docker-registry/templates/poddisruptionbudget.yaml
+++ b/charts/docker-registry/templates/poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "docker-registry.fullname" . }}
+  labels:
+    app: {{ template "docker-registry.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "docker-registry.name" . }}
+      release: {{ .Release.Name }}
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/charts/docker-registry/templates/pvc.yaml
+++ b/charts/docker-registry/templates/pvc.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.persistence.enabled }}
+{{- if not .Values.persistence.existingClaim -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "docker-registry.fullname" . }}
+  labels:
+    app: {{ template "docker-registry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/docker-registry/templates/secret.yaml
+++ b/charts/docker-registry/templates/secret.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "docker-registry.fullname" . }}-secret
+  labels:
+    app: {{ template "docker-registry.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  {{- if .Values.secrets.htpasswd }}
+  htpasswd: {{ .Values.secrets.htpasswd | b64enc }}
+  {{- end }}
+  {{- if .Values.secrets.haSharedSecret }}
+  haSharedSecret: {{ .Values.secrets.haSharedSecret | b64enc | quote }}
+  {{- else }}
+  haSharedSecret: {{ randAlphaNum 16 | b64enc | quote }}
+  {{- end }}
+  
+  {{- if eq .Values.storage "azure" }}
+    {{- if and .Values.secrets.azure.accountName .Values.secrets.azure.accountKey .Values.secrets.azure.container }}
+  azureAccountName: {{ .Values.secrets.azure.accountName | b64enc | quote }}
+  azureAccountKey: {{ .Values.secrets.azure.accountKey | b64enc | quote }}
+  azureContainer: {{ .Values.secrets.azure.container | b64enc | quote }}
+    {{- end }}
+  {{- else if eq .Values.storage "s3" }}
+    {{- if and .Values.secrets.s3.secretKey .Values.secrets.s3.accessKey }}
+  s3AccessKey: {{ .Values.secrets.s3.accessKey | b64enc | quote }}
+  s3SecretKey: {{ .Values.secrets.s3.secretKey | b64enc | quote }}
+    {{- end }}
+  {{- else if eq .Values.storage "swift" }}
+    {{- if and .Values.secrets.swift.username .Values.secrets.swift.password }}
+  swiftUsername: {{ .Values.secrets.swift.username | b64enc | quote }}
+  swiftPassword: {{ .Values.secrets.swift.password | b64enc | quote }}
+    {{- end }}
+  {{- end }}

--- a/charts/docker-registry/templates/service.yaml
+++ b/charts/docker-registry/templates/service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "docker-registry.fullname" . }}
+  labels:
+    app: {{ template "docker-registry.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+{{- if (and (eq .Values.service.type "ClusterIP") (not (empty .Values.service.clusterIP))) }}
+  clusterIP: {{ .Values.service.clusterIP }}
+{{- end }}
+  ports:
+    - port: {{ .Values.service.port }}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+      targetPort: 5000
+{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{ .Values.service.nodePort }}
+{{- end }}
+  selector:
+    app: {{ template "docker-registry.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/docker-registry/values.yaml
+++ b/charts/docker-registry/values.yaml
@@ -1,0 +1,145 @@
+# Default values for docker-registry.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+
+updateStrategy:
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 0
+
+podAnnotations: {}
+podLabels: {}
+
+image:
+  repository: registry
+  tag: 2.7.1
+  pullPolicy: IfNotPresent
+# imagePullSecrets:
+    # - name: docker
+service:
+  name: registry
+  type: ClusterIP
+  # clusterIP:
+  port: 5000
+  # nodePort:
+  annotations: {}
+  # foo.io/bar: "true"
+ingress:
+  enabled: false
+  path: /
+  # Used to create an Ingress record.
+  hosts:
+    - chart-example.local
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  labels: {}
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+persistence:
+  accessMode: 'ReadWriteOnce'
+  enabled: false
+  size: 10Gi
+  # storageClass: '-'
+
+# set the type of filesystem to use: filesystem, s3
+storage: filesystem
+
+# Set this to name of secret for tls certs
+# tlsSecretName: registry.docker.example.com
+secrets:
+  haSharedSecret: ""
+  htpasswd: ""
+# Secrets for Azure
+#   azure:
+#     accountName: ""
+#     accountKey: ""
+#     container: ""
+# Secrets for S3 access and secret keys
+#   s3:
+#     accessKey: ""
+#     secretKey: ""
+# Secrets for Swift username and password
+#   swift:
+#     username: ""
+#     password: ""
+
+# Options for s3 storage type:
+# s3:
+#  region: us-east-1
+#  regionEndpoint: s3.us-east-1.amazonaws.com
+#  bucket: my-bucket
+#  encrypt: false
+#  secure: true
+
+# Options for swift storage type:
+# swift:
+#  authurl: http://swift.example.com/
+#  container: my-container
+
+configData:
+  version: 0.1
+  log:
+    fields:
+      service: registry
+  storage:
+    cache:
+      blobdescriptor: inmemory
+  http:
+    addr: :5000
+    headers:
+      X-Content-Type-Options: [nosniff]
+  health:
+    storagedriver:
+      enabled: true
+      interval: 10s
+      threshold: 3
+
+securityContext:
+  enabled: true
+  runAsUser: 1000
+  fsGroup: 1000
+
+priorityClassName: ""
+
+podDisruptionBudget: {}
+  # maxUnavailable: 1
+  # minAvailable: 2
+
+nodeSelector: {}
+
+affinity: {}
+
+tolerations: []
+
+extraVolumeMounts: []
+## Additional volumeMounts to the registry container.
+#  - mountPath: /secret-data
+#    name: cloudfront-pem-secret
+#    readOnly: true
+
+extraVolumes: []
+## Additional volumes to the pod.
+#  - name: cloudfront-pem-secret
+#    secret:
+#      secretName: cloudfront-credentials
+#      items:
+#        - key: cloudfront.pem
+#          path: cloudfront.pem
+#          mode: 511

--- a/charts/docker-registry/values.yaml
+++ b/charts/docker-registry/values.yaml
@@ -75,6 +75,11 @@ secrets:
 #   s3:
 #     accessKey: ""
 #     secretKey: ""
+#    # Or use an existing secret
+#     existingSecret:
+#       name: ""
+#       s3AccessKeySecretKey: "s3AccessKey"
+#       s3SecretKeySecretKey: "s3SecretKey"
 # Secrets for Swift username and password
 #   swift:
 #     username: ""


### PR DESCRIPTION
This is just a copy of docker registry helm chart to our repo. I want to customize secret configuration, currently it's not possible to pass existing secret, you are required to pass S3 credentials in helm values which is not secure. Check the last commit to see secret configuration changes.